### PR TITLE
 Request validation

### DIFF
--- a/0x01-Basic_authentication/archive.zip/api/v1/app.py
+++ b/0x01-Basic_authentication/archive.zip/api/v1/app.py
@@ -6,12 +6,34 @@ from os import getenv
 from api.v1.views import app_views
 from flask import Flask, jsonify, abort, request
 from flask_cors import (CORS, cross_origin)
+from api.v1.auth.auth import Auth
 import os
 
 
 app = Flask(__name__)
 app.register_blueprint(app_views)
 CORS(app, resources={r"/api/v1/*": {"origins": "*"}})
+auth = None
+
+auth_type = getenv("AUTH_TYPE")
+""" load and assign the right instance of authentication to auth"""
+if auth_type:
+    if auth_type == "basic_auth":
+        auth = Auth()
+
+
+@app.before_request
+def request_filter() -> str:
+    """
+    Checks if the requested path requires authentication
+    """
+    excluded_paths = ['/api/v1/status/', '/api/v1/unauthorized/',
+                      '/api/v1/forbidden/']
+    if auth is not None and auth.require_auth(request.path, excluded_paths):
+        if auth.authorization_header(request) is None:
+            abort(401)
+        if auth.current_user(request) is None:
+            abort(403)
 
 
 @app.errorhandler(404)

--- a/0x01-Basic_authentication/archive.zip/api/v1/auth/auth.py
+++ b/0x01-Basic_authentication/archive.zip/api/v1/auth/auth.py
@@ -62,6 +62,11 @@ class Auth:
             return None
         return auth
 
+    uth_header = request.headers.get('Authorization', None)
+    if auth_header is None:
+        return None
+        return auth_header
+
     def current_user(self, request=None) -> TypeVar('User'):
         """
         Retrieves the current authenticated user.


### PR DESCRIPTION
Update the method def authorization_header(self, request=None) -> str: in api/v1/auth/auth.py:

If request is None, returns None
If request doesn’t contain the header key Authorization, returns None
Otherwise, return the value of the header request Authorization


ate the file api/v1/app.py:

Create a variable auth initialized to None after the CORS definition
Based on the environment variable AUTH_TYPE, load and assign the right instance of authentication to auth
if auth:

Add a method in api/v1/app.py to handler before_request