### PR TITLE
Log out

### DIFF
--- a/0x03-user_authentication_service/app.py
+++ b/0x03-user_authentication_service/app.py
@@ -46,5 +46,17 @@ def login():
         abort(401)
 
 
+@app.route("/sessions", methods=["DELETE"], strict_slashes=False)
+def logout():
+    """Logs out a login user
+    """
+    session_id = request.cookies.get("session_id")
+    user = AUTH.get_user_from_session_id(session_id)
+    if user is not None:
+        AUTH.destroy_session(user.id)
+        return redirect("/")
+    abort(403)
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port="5000")


### PR DESCRIPTION
 implement a logout function to respond to the DELETE /sessions route.

The request is expected to contain the session ID as a cookie with key "session_id".

Find the user with the requested session ID. If the user exists destroy the session and redirect the user to GET /. If the user does not exist, respond with a 403 HTTP status.